### PR TITLE
Extract OpenSearch data stream compatibility in verrazzano fork

### DIFF
--- a/plugins/out_opensearch/opensearch.c
+++ b/plugins/out_opensearch/opensearch.c
@@ -27,6 +27,7 @@
 #include <fluent-bit/flb_aws_credentials.h>
 #include <fluent-bit/flb_record_accessor.h>
 #include <fluent-bit/flb_ra_key.h>
+#include <fluent-bit/flb_file.h>
 #include <msgpack.h>
 
 #include <cfl/cfl.h>
@@ -223,6 +224,48 @@ static flb_sds_t os_get_id_value(struct flb_opensearch *ctx,
     return tmp_str;
 }
 
+static void create_ra_index(struct flb_opensearch *ctx,
+                      struct flb_record_accessor *rec,
+                      flb_sds_t *ra_index,
+                      const char* tag,
+                      int tag_len,
+                      struct msgpack_object map,
+                      int *index_len,
+                      flb_sds_t *j_index,
+                      char** index)
+{
+    if (*ra_index != NULL) {
+        flb_sds_destroy(*ra_index);
+    }
+    /* a record accessor pattern exists for the index */
+    *ra_index = flb_ra_translate(rec,
+                                (char *) tag, tag_len,
+                                map, NULL);
+    if (*ra_index ==  NULL) {
+        flb_plg_warn(ctx->ins,
+                     "invalid data stream from record accessor pattern, default to static index");
+    }
+    else {
+        *index = *ra_index;
+    }
+
+    if (ctx->suppress_type_name) {
+        *index_len = flb_sds_snprintf(j_index,
+                                     flb_sds_alloc(*j_index),
+                                     OS_BULK_INDEX_FMT_NO_TYPE,
+                                     ctx->action,
+                                     *index);
+    }
+    else {
+        *index_len = flb_sds_snprintf(j_index,
+                                     flb_sds_alloc(*j_index),
+                                     OS_BULK_INDEX_FMT,
+                                     ctx->action,
+                                     *index, ctx->type);
+    }
+
+}
+
 /*
  * Convert the internal Fluent Bit data representation to the required
  * one by OpenSearch.
@@ -247,6 +290,7 @@ static int opensearch_format(struct flb_config *config,
     size_t off = 0;
     char *p;
     char *index = NULL;
+    char *unformatted_index = NULL;
     char logstash_index[256];
     char time_formatted[256];
     char index_formatted[256];
@@ -267,6 +311,8 @@ static int opensearch_format(struct flb_config *config,
     int index_custom_len;
     struct flb_opensearch *ctx = plugin_context;
     flb_sds_t j_index;
+    int enabled_data_stream_no_ra;
+    int disabled_logstash_fmt_no_ra;
 
     j_index = flb_sds_create_size(FLB_OS_HEADER_SIZE);
     if (j_index == NULL) {
@@ -322,38 +368,65 @@ static int opensearch_format(struct flb_config *config,
     }
 
     /*
-     * If logstash format and id generation are disabled, pre-generate
+     * If data stream mode is enabled without record accessor syntax
+     * or logstash format and id generation are disabled, pre-generate
      * the index line for all records.
      *
      * The header stored in 'j_index' will be used for the all records on
      * this payload.
      */
-    if (ctx->logstash_format == FLB_FALSE && ctx->generate_id == FLB_FALSE && ctx->ra_index == NULL) {
-        flb_time_get(&tms);
-        gmtime_r(&tms.tm.tv_sec, &tm);
-        strftime(index_formatted, sizeof(index_formatted) - 1,
-                 ctx->index, &tm);
-        index = index_formatted;
-        if (ctx->suppress_type_name) {
-            index_len = flb_sds_snprintf(&j_index,
-                                         flb_sds_alloc(j_index),
-                                         OS_BULK_INDEX_FMT_NO_TYPE,
-                                         ctx->action,
-                                         index);
-        }
-        else {
-            index_len = flb_sds_snprintf(&j_index,
-                                         flb_sds_alloc(j_index),
-                                         OS_BULK_INDEX_FMT,
-                                         ctx->action,
-                                         index, ctx->type);
-        }
 
-        if (index_len == -1) {
-            msgpack_unpacked_destroy(&result);
-            flb_sds_destroy(bulk);
-            flb_sds_destroy(j_index);
-            return -1;
+    if (ctx->data_stream_mode == FLB_TRUE &&
+        ctx->ra_data_stream == NULL) {
+        enabled_data_stream_no_ra = FLB_TRUE;
+    }
+    else {
+        enabled_data_stream_no_ra = FLB_FALSE;
+    }
+
+    if (ctx->logstash_format == FLB_FALSE &&
+        ctx->ra_index == NULL) {
+        disabled_logstash_fmt_no_ra = FLB_TRUE;
+    }
+    else {
+        disabled_logstash_fmt_no_ra =  FLB_FALSE;
+    }
+
+    if ((enabled_data_stream_no_ra ==  FLB_TRUE ||
+        disabled_logstash_fmt_no_ra == FLB_TRUE) &&
+        ctx->generate_id == FLB_FALSE) {
+        if(ctx->data_stream_mode == FLB_TRUE) {
+            unformatted_index = ctx->data_stream_name;
+        }
+        else if (ctx->logstash_format == FLB_FALSE) {
+            unformatted_index = ctx->index;
+        }
+        if (unformatted_index != NULL) {
+            flb_time_get(&tms);
+            gmtime_r(&tms.tm.tv_sec, &tm);
+            strftime(index_formatted, sizeof(index_formatted) - 1,
+                     unformatted_index, &tm);
+            index = index_formatted;
+            if (ctx->suppress_type_name) {
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             OS_BULK_INDEX_FMT_NO_TYPE,
+                                             ctx->action,
+                                             index);
+            } else {
+                index_len = flb_sds_snprintf(&j_index,
+                                             flb_sds_alloc(j_index),
+                                             OS_BULK_INDEX_FMT,
+                                             ctx->action,
+                                             index, ctx->type);
+            }
+
+            if (index_len == -1) {
+                msgpack_unpacked_destroy(&result);
+                flb_sds_destroy(bulk);
+                flb_sds_destroy(j_index);
+                return -1;
+            }
         }
     }
 
@@ -439,10 +512,25 @@ static int opensearch_format(struct flb_config *config,
         msgpack_pack_str_body(&tmp_pck, time_formatted, s);
 
         index = ctx->index;
-        if (ctx->logstash_format == FLB_TRUE) {
+
+        if (ctx->data_stream_mode == FLB_TRUE) {
+            index = ctx->data_stream_name;
+            if (ctx->ra_data_stream) {
+                create_ra_index(ctx,
+                                ctx->ra_data_stream,
+                                &ra_index,
+                                tag, tag_len,
+                                map,
+                                &index_len,
+                                &j_index, &index);
+
+            }
+        }
+        else if (ctx->logstash_format == FLB_TRUE) {
             /* Compose Index header */
             if (index_custom_len > 0) {
                 p = logstash_index + index_custom_len;
+
             }
             else {
                 p = logstash_index + flb_sds_len(ctx->logstash_prefix);
@@ -479,35 +567,13 @@ static int opensearch_format(struct flb_config *config,
             index = index_formatted;
         }
         else if (ctx->ra_index) {
-            // free any previous ra_index to avoid memory leaks.
-            if (ra_index != NULL) {
-                flb_sds_destroy(ra_index);
-            }
-            /* a record accessor pattern exists for the index */
-            ra_index = flb_ra_translate(ctx->ra_index,
-                                           (char *) tag, tag_len,
-                                           map, NULL);
-            if (!ra_index) {
-                flb_plg_warn(ctx->ins, "invalid index translation from record accessor pattern, default to static index");
-            }
-            else {
-                index = ra_index;
-            }
-
-            if (ctx->suppress_type_name) {
-                index_len = flb_sds_snprintf(&j_index,
-                                             flb_sds_alloc(j_index),
-                                             OS_BULK_INDEX_FMT_NO_TYPE,
-                                             ctx->action,
-                                             index);
-            }
-            else {
-                index_len = flb_sds_snprintf(&j_index,
-                                             flb_sds_alloc(j_index),
-                                             OS_BULK_INDEX_FMT,
-                                             ctx->action,
-                                             index, ctx->type);
-            }
+            create_ra_index(ctx,
+                            ctx->ra_index,
+                            &ra_index,
+                            tag, tag_len,
+                            map,
+                            &index_len,
+                            &j_index, &index);
         }
 
         /* Tag Key */
@@ -851,12 +917,169 @@ static int opensearch_error_check(struct flb_opensearch *ctx,
     return check;
 }
 
+static int put_index_template(struct flb_opensearch *ctx)
+{
+    int res;
+    size_t b;
+    struct flb_http_client *c = NULL;
+    flb_sds_t template;
+    struct flb_connection *u_conn;
+
+    u_conn = flb_upstream_conn_get(ctx->u);
+
+    if (!u_conn) {
+        return FLB_OS_RETRY;
+    }
+
+    template = flb_file_read(ctx->template_file);
+
+    /*
+     * template does not exist so retry
+     */
+    if(template == NULL || flb_sds_len(template) == 0) {
+        flb_errno();
+        flb_plg_debug(ctx->ins, "failed to read template file");
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_RETRY;
+    }
+
+    c = flb_http_client(u_conn, FLB_HTTP_PUT, ctx->template_uri,
+                        template, flb_sds_len(template), NULL,
+                        0, NULL, 0);
+
+    if (!c) {
+        flb_plg_debug(ctx->ins,
+                      "failed to create http client");
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_RETRY;
+    }
+
+    if (ctx->http_user && ctx->http_passwd) {
+        flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    }
+    flb_http_add_header(c, "Content-Type", 12, "application/json", 16);
+
+    res = flb_http_do(c, &b);
+    if(res != 0) {
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(template);
+        return FLB_OS_RETRY;
+    }
+    if(c->resp.status != 200 && c->resp.status != 201) {
+        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ctx->template_uri);
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        flb_sds_destroy(template);
+        return FLB_OS_RETRY;
+    }
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+    flb_sds_destroy(template);
+
+    return FLB_OS_SUCCESS;
+}
+
+static int template_exists(struct flb_opensearch *ctx) {
+    struct flb_connection *u_conn;
+    int res;
+    size_t b;
+    struct flb_http_client *c = NULL;
+    u_conn = flb_upstream_conn_get(ctx->u);
+
+    if (!u_conn) {
+        return FLB_OS_RETRY;
+    }
+
+    c = flb_http_client(u_conn, FLB_HTTP_GET, ctx->template_uri,
+                        NULL, 0, NULL,
+                        0, NULL, 0);
+
+    if (!c) {
+        flb_plg_debug(ctx->ins,
+                      "failed to create http client");
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_RETRY;
+    }
+    if (ctx->http_user && ctx->http_passwd) {
+        flb_http_basic_auth(c, ctx->http_user, ctx->http_passwd);
+    }
+
+    res = flb_http_do(c, &b);
+
+    if(res != 0) {
+        flb_plg_debug(ctx->ins, "result of http do function for GET template client %i", res);
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_RETRY;
+    }
+
+    if (c->resp.status == 404) {
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_NOT_FOUND;
+    }
+
+    if(c->resp.status != 200 && c->resp.status != 201) {
+        flb_plg_debug(ctx->ins, "HTTP Status=%i URI=%s", c->resp.status, ctx->template_uri);
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return FLB_OS_RETRY;
+    }
+
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+
+    return FLB_OS_SUCCESS;
+
+}
+
+static int create_index_template(struct flb_opensearch *ctx)
+{
+    int res;
+    /*
+     * create index template from the given file path
+     * retry if the file path is not set or if the template is missing
+     */
+    if (ctx->template_file) {
+        if (ctx->template_overwrite == FLB_TRUE) {
+            return put_index_template(ctx);
+        }
+        else {
+            res = template_exists(ctx);
+            if (res == FLB_OS_SUCCESS) {
+                flb_plg_debug(ctx->ins,
+                              "template with given name %s exists",
+                              ctx->data_stream_template_name);
+                return FLB_OS_SUCCESS;
+            }
+            else if (res == FLB_OS_NOT_FOUND) {
+                flb_plg_debug(ctx->ins,
+                              "template with given name %s does not exist, creating it now",
+                              ctx->data_stream_template_name);
+                return put_index_template(ctx);
+            }
+            else {
+                flb_plg_error(ctx->ins,
+                              "error checking if the template exists, retrying");
+                return FLB_OS_RETRY;
+            }
+        }
+    }
+
+    flb_plg_error(ctx->ins,
+                  "template_file needs to be set to the absolute path of the index template file");
+    return FLB_OS_RETRY;
+
+}
+
 static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
                                 struct flb_output_flush *out_flush,
                                 struct flb_input_instance *ins, void *out_context,
                                 struct flb_config *config)
 {
     int ret;
+    int res;
     size_t pack_size;
     char *pack;
     void *out_buf;
@@ -871,6 +1094,18 @@ static void cb_opensearch_flush(struct flb_event_chunk *event_chunk,
     u_conn = flb_upstream_conn_get(ctx->u);
     if (!u_conn) {
         FLB_OUTPUT_RETURN(FLB_RETRY);
+    }
+
+    /*
+     * create index template if data stream mode is enabled
+    */
+
+    if (ctx->data_stream_mode == FLB_TRUE) {
+        res = create_index_template(ctx);
+        flb_plg_debug(ctx->ins, "create index template=%i", res);
+        if (res != 0) {
+            FLB_OUTPUT_RETURN(FLB_RETRY);
+        }
     }
 
     /* Convert format */
@@ -1064,6 +1299,33 @@ static struct flb_config_map config_map[] = {
      "External ID for the AWS IAM Role specified with `aws_role_arn`"
     },
 #endif
+    /* Data stream compatibility */
+    {
+     FLB_CONFIG_MAP_BOOL, "data_stream_mode", "false",
+     0, FLB_TRUE, offsetof(struct flb_opensearch, data_stream_mode),
+     "Enable data stream mode"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "data_stream_name", FLB_OS_DEFAULT_INDEX,
+     0, FLB_TRUE, offsetof(struct flb_opensearch, data_stream_name),
+     "Set the name of the target data stream"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "data_stream_template_name", FLB_OS_DEFAULT_TEMPLATE,
+     0, FLB_TRUE, offsetof(struct flb_opensearch, data_stream_template_name),
+     "Set name of the index template corresponding to the data stream"
+    },
+    {
+     FLB_CONFIG_MAP_STR, "template_file", NULL,
+     0, FLB_TRUE, offsetof(struct flb_opensearch, template_file),
+     "Location of the index template file"
+    },
+    {
+     FLB_CONFIG_MAP_BOOL, "template_overwrite", "false",
+     0, FLB_TRUE, offsetof(struct flb_opensearch, template_overwrite),
+     "Overwrite the index template even if it exists"
+    },
+
 
     /* Logstash compatibility */
     {

--- a/plugins/out_opensearch/opensearch.h
+++ b/plugins/out_opensearch/opensearch.h
@@ -24,6 +24,7 @@
 #define FLB_OS_DEFAULT_HOST       "127.0.0.1"
 #define FLB_OS_DEFAULT_PORT       92000
 #define FLB_OS_DEFAULT_INDEX      "fluent-bit"
+#define FLB_OS_DEFAULT_TEMPLATE   "fluent-bit_template"
 #define FLB_OS_DEFAULT_TYPE       "_doc"
 #define FLB_OS_DEFAULT_PREFIX     "logstash"
 #define FLB_OS_DEFAULT_TIME_FMT   "%Y.%m.%d"
@@ -35,6 +36,9 @@
 #define FLB_OS_WRITE_OP_CREATE    "create"
 #define FLB_OS_WRITE_OP_UPDATE    "update"
 #define FLB_OS_WRITE_OP_UPSERT    "upsert"
+#define FLB_OS_RETRY               -1
+#define FLB_OS_SUCCESS             0
+#define FLB_OS_NOT_FOUND           1
 
 /* macros */
 #define FLB_OS_HEADER_SIZE        1024
@@ -87,6 +91,16 @@ struct flb_opensearch {
     int trace_error;
 
     /*
+     * OpenSearch data stream options
+     */
+    int data_stream_mode;
+    char *data_stream_name;
+    char *data_stream_template_name;
+    char *template_file;
+    int template_overwrite;
+    struct flb_record_accessor *ra_data_stream;
+
+    /*
      * Logstash compatibility options
      * ==============================
      */
@@ -130,6 +144,8 @@ struct flb_opensearch {
 
     /* HTTP API */
     char uri[1024];
+    char template_uri[1024];
+    char ds_uri[1024];
 
     struct flb_record_accessor *ra_prefix_key;
 

--- a/plugins/out_opensearch/os_conf.c
+++ b/plugins/out_opensearch/os_conf.c
@@ -111,13 +111,24 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
         /* Check if the index has been set in the configuration */
         if (ctx->index) {
             /* do we have a record accessor pattern ? */
-            if (strchr(ctx->index, '$')) {
+            if (strchr(ctx->index, '$') != NULL) {
                 ctx->ra_index = flb_ra_create(ctx->index, FLB_TRUE);
                 if (!ctx->ra_index) {
                     flb_plg_error(ctx->ins, "invalid record accessor pattern set for 'index' property");
                     flb_os_conf_destroy(ctx);
                     return NULL;
                 }
+            }
+        }
+    }
+
+    if(ctx->data_stream_name) {
+        if(strchr(ctx->data_stream_name, '$') != NULL) {
+            ctx->ra_data_stream = flb_ra_create(ctx->data_stream_name, FLB_TRUE);
+            if(!ctx->ra_data_stream) {
+                flb_plg_error(ctx->ins, "invalid record accessor pattern set for 'data_stream_name' property");
+                flb_os_conf_destroy(ctx);
+                return NULL;
             }
         }
     }
@@ -146,6 +157,14 @@ struct flb_opensearch *flb_os_conf_create(struct flb_output_instance *ins,
         snprintf(ctx->uri, sizeof(ctx->uri) - 1, "%s/_bulk", path);
     }
 
+    snprintf(ctx->template_uri,
+             sizeof(ctx->template_uri) - 1,
+             "%s/_index_template/%s",
+             path, ctx->data_stream_template_name);
+    snprintf(ctx->ds_uri,
+             sizeof(ctx->ds_uri) - 1,
+             "%s/_data_stream/%s",
+             path, ctx->data_stream_name);
 
     if (ctx->id_key) {
         ctx->ra_id_key = flb_ra_create(ctx->id_key, FLB_FALSE);
@@ -372,6 +391,11 @@ int flb_os_conf_destroy(struct flb_opensearch *ctx)
 
     if (ctx->ra_index) {
         flb_ra_destroy(ctx->ra_index);
+    }
+
+    if (ctx->ra_data_stream != NULL) {
+        flb_ra_destroy(ctx->ra_data_stream);
+        ctx->ra_data_stream = NULL;
     }
 
     flb_free(ctx);


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
