### PR TITLE
VZ-10506: Reduce Image size for fluentbit by creating multiple build stage.

### DIFF
--- a/dockerfiles/Dockerfile.oracle
+++ b/dockerfiles/Dockerfile.oracle
@@ -45,9 +45,12 @@ RUN cmake -DFLB_RELEASE=On \
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
 
-# Download all required RPM package locally then extract them into a directory.
-RUN microdnf --enablerepo=ol9_codeready_builder download --resolve --nodocs -y \
+# Download required RPM package locally then extract them into a directory.
+RUN microdnf --enablerepo=ol9_codeready_builder download --nodocs -y \
     systemd-devel \
+    systemd-libs \
+    openldap-compat \
+    libpq \
     libpq-devel && \
     microdnf clean all && \
     for rpm in *.rpm; do \

--- a/dockerfiles/Dockerfile.oracle
+++ b/dockerfiles/Dockerfile.oracle
@@ -1,6 +1,6 @@
 FROM ghcr.io/verrazzano/verrazzano-base-ol9:v1.0.0-20230627070315-744eefa as builder-base
 
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
+RUN mkdir -p /fluent-bit/bin /fluent-bit/log /fluent-bit/rpm
 
 RUN microdnf -y module enable postgresql:15 \
     && microdnf --enablerepo=ol9_codeready_builder install -y \
@@ -20,12 +20,13 @@ RUN microdnf -y module enable postgresql:15 \
     bison \
     libyaml-devel \
     postgresql postgresql-server \
+    cpio \
     && microdnf clean all
 
 WORKDIR /src/fluent-bit/
 COPY . ./
 
-FROM builder-base
+FROM builder-base as fluentbit-builder
 WORKDIR /src/fluent-bit/build/
 RUN cmake -DFLB_RELEASE=On \
     -DFLB_JEMALLOC=On \
@@ -44,6 +45,19 @@ RUN cmake -DFLB_RELEASE=On \
 RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
 
+# Download all required RPM package locally then extract them into a directory.
+RUN microdnf --enablerepo=ol9_codeready_builder download --resolve --nodocs -y \
+    systemd-devel \
+    libpq-devel && \
+    microdnf clean all && \
+    for rpm in *.rpm; do \
+    echo "Processing: ${rpm}"; \
+    rpm2cpio ${rpm} | cpio -idmv -D /fluent-bit/rpm/; \
+    done
+
+FROM ghcr.io/verrazzano/verrazzano-base-ol9:v1.0.0-20230627070315-744eefa
+WORKDIR /fluent-bit
+
 COPY conf/fluent-bit.conf \
     conf/parsers.conf \
     conf/parsers_ambassador.conf \
@@ -54,8 +68,12 @@ COPY conf/fluent-bit.conf \
     conf/plugins.conf \
     /fluent-bit/etc/
 
-# Generate schema and include as part of the container image
-RUN /fluent-bit/bin/fluent-bit -J > /fluent-bit/etc/schema.json
+# Copy Fluent-bit binary
+COPY --from=fluentbit-builder /fluent-bit/bin/ /fluent-bit/bin/
+
+# Copy Dependencies
+COPY --from=fluentbit-builder /fluent-bit/rpm/usr/lib /usr/lib
+COPY --from=fluentbit-builder /fluent-bit/rpm/usr/lib64 /usr/lib64
 
 RUN mkdir -p /license
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/

--- a/dockerfiles/Dockerfile.oracle
+++ b/dockerfiles/Dockerfile.oracle
@@ -78,6 +78,8 @@ COPY --from=fluentbit-builder /fluent-bit/bin/ /fluent-bit/bin/
 COPY --from=fluentbit-builder /fluent-bit/rpm/usr/lib /usr/lib
 COPY --from=fluentbit-builder /fluent-bit/rpm/usr/lib64 /usr/lib64
 
+# Generate schema and include as part of the container image
+RUN /fluent-bit/bin/fluent-bit -J > /fluent-bit/etc/schema.json
 RUN mkdir -p /license
 COPY LICENSE README.md THIRD_PARTY_LICENSES.txt /license/
 


### PR DESCRIPTION
1. Separate Dockerfile in multilple build stage.
2. download/extract the dependncies instead of installing.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
